### PR TITLE
Labour victory (based on exit poll)

### DIFF
--- a/election.yml
+++ b/election.yml
@@ -1,8 +1,8 @@
 data:
-  election: true
+  election: false
   party:
-    - CON
-  date: 2024-07-04
+    - LAB
+  date: 2029-08-25
   reason: CALLED
 
 config:

--- a/election.yml
+++ b/election.yml
@@ -3,7 +3,7 @@ data:
   party:
     - LAB
   date: 2029-08-25
-  reason: CALLED
+  reason: NORMAL
 
 config:
   parties:


### PR DESCRIPTION
To provide a way for me to update this before I fall asleep:

The exit poll provided puts Labour at a 410-seat projection. This PR - assuming this is correct - will reset the counter (no timeframe on IoG so speculative based on date called). Since is the most likely outcome, this becomes an easy merge. Otherwise, I will update in the "morning".